### PR TITLE
Fix typo in Careers menu option

### DIFF
--- a/_pages/careers.md
+++ b/_pages/careers.md
@@ -1,7 +1,7 @@
 ---
 layout: redirect
-title: Carrers
-permalink: /carrers/
+title: Careers
+permalink: /careers/
 link: https://simonsfoundation.wd1.myworkdayjobs.com/en-US/simonsfoundationcareers/job/162-Fifth-Avenue/Flatiron-Research-Fellow--Center-for-Computational-Neuroscience_R0000686
 nav: true
 ---


### PR DESCRIPTION
Used to be "Carrers". The `permalink` was also mistyped.